### PR TITLE
Update to Python 3.12

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "matangover.mypy",
+        "ms-python.python"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
+    "mypy.enabled": false,
+    "mypy.runUsingActiveInterpreter": true,
     "python.REPL.enableREPLSmartSend": false,
     "editor.formatOnSave": false
 }

--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ python generate.py
 
 ## Install
 
-This project requires Python 3.11, JAX 0.4.25.
+This project requires Python 3.12, JAX 0.4.26.
 
 Create venv:
 
 ```sh
-python3.11 -m venv venv
+python3.12 -m venv venv
+. venv/bin/activate
 ```
 
 Install dependencies:

--- a/mistral/lib/parsec/Either.py
+++ b/mistral/lib/parsec/Either.py
@@ -3,11 +3,9 @@ from typing import Generic, TypeVar
 T = TypeVar('T')
 E = TypeVar('E')
 
-class Either(Generic[T, E]):
-    def is_success(self) -> bool:
-        raise NotImplementedError('Subclasses should implement this method')
+type Either[T, E] = success[T] | fail[E]
 
-class success(Either[T, E]):
+class success(Generic[T]):
     def __init__(self, value: T):
         self.value = value
 
@@ -25,7 +23,7 @@ class success(Either[T, E]):
             return False
         return self.value == other.value
 
-class fail(Either[T, E]):
+class fail(Generic[E]):
     def __init__(self, error: E):
         self.error = error
 

--- a/mistral/lib/parsec/Void.py
+++ b/mistral/lib/parsec/Void.py
@@ -1,3 +1,5 @@
+from typing import NoReturn
+
 class VoidType:
     '''A private class to implement the singleton pattern.'''
     def __repr__(self):
@@ -5,10 +7,10 @@ class VoidType:
 
 Void = VoidType()
 
-def _void_type_new(cls):
+def _void_type_new(cls) -> NoReturn:
     raise RuntimeError('VoidType cannot be instantiated directly')
 
-def _void_type_init_subclass(cls, **kwargs):
+def _void_type_init_subclass(cls, **kwargs) -> NoReturn:
     raise RuntimeError('Subclassing VoidType is not allowed')
 
 VoidType.__new__ = _void_type_new

--- a/mistral/lib/parsec/parsec.py
+++ b/mistral/lib/parsec/parsec.py
@@ -5,18 +5,19 @@ from typing import Callable, TypeVar
 from .Either import Either, success, fail
 from .Void import Void, VoidType
 
-Position = int
-ErrorType = str
-R = TypeVar('R')
 U = TypeVar('U')
 V = TypeVar('V')
 
-ParseResultSucceeded = tuple[Position, R]
-ParseResultFailed = tuple[Position, ErrorType]
-ParseResult = Either[ParseResultSucceeded, ParseResultFailed]
-Parser = Callable[[str, Position], ParseResult[R]]
-ParserSucceeded = Callable[[str, Position], ParseResultSucceeded[R]]
-ParserFailed = Callable[[str, Position], ParseResultFailed]
+type Position = int
+type ErrorType = str
+
+type ParseResultSucceeded[U] = tuple[Position, U]
+type ParseResultFailed = tuple[Position, ErrorType]
+type ParseResult[U] = Either[ParseResultSucceeded[U], ParseResultFailed]
+
+type ParserSucceeded[U] = Callable[[str, Position], ParseResultSucceeded[U]]
+type ParserFailed = Callable[[str, Position], ParseResultFailed]
+type Parser[U] = Callable[[str, Position], ParseResult[U]]
 
 def satisfy(predicate: Callable[[str], bool], desc: str) -> Parser[str]:
     def f(s: str, idx: Position) -> ParseResult[str]:


### PR DESCRIPTION
Update codebase to Python 3.12. Note that mypy does not support the `type` soft keyword yet, so unfortunately it have to be disabled in the codebase. See <https://github.com/python/mypy/issues/15238>.