### PR TITLE
Update einshard syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ However, the existing APIs for defining the split shapes were not intuitive enou
 
 While `einshard` worked well on CPUs and TPU v3-8, issues arose when running on TPU v4-32 due to its configuration of 4 hosts requiring cross-host partitioning, which `jax.device_put()` could not achieve. To overcome this, `jax.make_array_from_callback()` was used as a replacement.
 
-Further refinements and modifications to `einshard` are currently underway to enhance its functionality and adaptability.
+Further refinements and modifications have been introduced into `einshard` to enhance its functionality and adaptability.
 
 ### Generation with KVCache for a Single Sentence
 

--- a/mistral/model/attention.py
+++ b/mistral/model/attention.py
@@ -57,14 +57,14 @@ def shard_attention_params(params: AttentionParams) -> AttentionParams:
         AttentionParams: The attention parameters modified with tensor parallelism, allowing for distributed computation across multiple devices.
     """
     q_proj, k_proj, v_proj, o_proj = params
-    # q_proj = einshard(q_proj, 'm r h k -> m r h1 k')
-    # k_proj = einshard(k_proj, 'm h k -> m h1 k')
-    # v_proj = einshard(v_proj, 'm h v -> m h1 v')
-    # o_proj = einshard(o_proj, 'r h v m -> r h1 v m')
-    q_proj = einshard(q_proj, 'm r h k -> m r h k1')
-    k_proj = einshard(k_proj, 'm h k -> m h k1')
-    v_proj = einshard(v_proj, 'm h v -> m h v1')
-    o_proj = einshard(o_proj, 'r h v m -> r h v1 m')
+    # q_proj = einshard(q_proj, 'm r h k -> m r h1* k')
+    # k_proj = einshard(k_proj, 'm h k -> m h1* k')
+    # v_proj = einshard(v_proj, 'm h v -> m h1* v')
+    # o_proj = einshard(o_proj, 'r h v m -> r h1* v m')
+    q_proj = einshard(q_proj, 'm r h k -> m r h k1*')
+    k_proj = einshard(k_proj, 'm h k -> m h k1*')
+    v_proj = einshard(v_proj, 'm h v -> m h v1*')
+    o_proj = einshard(o_proj, 'r h v m -> r h v1* m')
     return q_proj, k_proj, v_proj, o_proj
 
 def forward_attention(params: AttentionParams, seq: Array, qk_mask: Array, rotary_values: RotaryValues, kv_cache_cur: KVCache, kv_cache_pre: KVCache) -> tuple[Array, KVCache, KVCache]:

--- a/mistral/model/mistral_lm.py
+++ b/mistral/model/mistral_lm.py
@@ -40,7 +40,7 @@ def shard_mistral_lm_params(params: MistralLMParams) -> MistralLMParams:
     """
     model_params, lm_head = params
     model_params = shard_mistral_model_params(model_params)
-    lm_head = einshard(lm_head, '... -> 1 ...')
+    lm_head = einshard(lm_head, '... -> 1* ...')
     return model_params, lm_head
 
 def forward_mistral_lm(params: MistralLMParams, input_ids: Array, qk_mask: Array, rotary_values: RotaryValues, kv_cache_pre: KVCache) -> tuple[Array, KVCache]:

--- a/mistral/model/mlp_layer.py
+++ b/mistral/model/mlp_layer.py
@@ -39,9 +39,9 @@ def shard_mlp_layer_params(params: MLPLayerParams) -> MLPLayerParams:
         MLPLayerParams: The decoder embedding parameters replica for distributed computation across multiple devices.
     """
     gate_proj, up_proj, down_proj = params
-    gate_proj = einshard(gate_proj, 'm f -> m f1')
-    up_proj = einshard(up_proj, 'm f -> m f1')
-    down_proj = einshard(down_proj, 'f m -> f1 m')
+    gate_proj = einshard(gate_proj, 'm f -> m f1*')
+    up_proj = einshard(up_proj, 'm f -> m f1*')
+    down_proj = einshard(down_proj, 'f m -> f1* m')
     return gate_proj, up_proj, down_proj
 
 def forward_mlp_layer(params: MLPLayerParams, seq: Array) -> Array:

--- a/mistral/model/rms_norm.py
+++ b/mistral/model/rms_norm.py
@@ -41,7 +41,7 @@ def shard_rms_norm_params(params: RMSNormParams) -> RMSNormParams:
     Returns:
         RMSNormParams: The rms norm parameters replica for distributed computation across multiple devices.
     """
-    return einshard(params, '... -> 1 ...')
+    return einshard(params, '... -> 1* ...')
 
 # Taken from https://github.com/ayaka14732/llama-2-jax/blob/main/lib/llama/rms_norm.py
 def forward_rms_norm(params: RMSNormParams, x: Array) -> Array:


### PR DESCRIPTION
Update einshard syntax according to our discussion.

Specifically, a single number now denotes an absolute value, while a number followed by an `*` denotes a proportional value. For example:

```
a b -> 2 a b1  # originally (2x, 1, x), now (2, 1, 1), where x is any positive integer
a b -> 2* a b1*  # not valid in the original version, now (2x, 1, x)
a b -> 2* a b1  # not valid in the original version, now (2x, 1, 1)
```