### PR TITLE
Simplify einshard syntax

### DIFF
--- a/mistral/lib/einshard/parser.py
+++ b/mistral/lib/einshard/parser.py
@@ -15,20 +15,28 @@ is_space: Callable[[str], bool] = lambda c: c.isspace()
 
 parse_0_to_9 = satisfy(is_0_to_9, 'digit 0-9')
 parse_1_to_9 = satisfy(is_1_to_9, 'digit 1-9')
+parse_integer = pmap(int, pjoin(pchain(parse_1_to_9, pjoin(many(parse_0_to_9)))))
+
 parse_identifier_char = satisfy(is_identifier_char, 'identifier')
 parse_identifier = pjoin(many1(parse_identifier_char))
+
 parse_space = satisfy(is_space, 'space')
 parse_spaces = many1(parse_space)
 parse_spaces_optional = pvoid(many(parse_space))
+
 parse_right_arrow = pvoid(literal('->'))
 parse_ellipsis = pmap(const(...), literal('...', desc='ellipsis'))
-parse_integer = pmap(int, pjoin(pchain(parse_1_to_9, pjoin(many(parse_0_to_9)))))
-parse_asterisk = with_default(pmap(const(True), literal('*')), default=False)
+parse_asterisk = pmap(const(True), literal('*'))
+
+parse_identifier_optional = with_default(parse_identifier, default=None)
+parse_integer_optional = with_default(parse_integer, default=1)
+parse_asterisk_optional = with_default(parse_asterisk, default=False)
 
 parse_element_left = anyof(parse_identifier, parse_ellipsis)
 parse_element_right = anyof(
-    pchain(with_default(parse_identifier, default=None), parse_integer, parse_asterisk),
-    pchain(parse_identifier, with_default(parse_integer, default=1), parse_asterisk),
+    pchain(parse_identifier_optional, parse_integer, parse_asterisk_optional),
+    pchain(parse_identifier, parse_integer_optional, parse_asterisk_optional),
+    pchain(parse_identifier_optional, parse_integer_optional, parse_asterisk),
     parse_ellipsis,
 )
 parse_elements_left = sepby1(parse_element_left, parse_spaces)

--- a/mistral/model/attention.py
+++ b/mistral/model/attention.py
@@ -57,14 +57,14 @@ def shard_attention_params(params: AttentionParams) -> AttentionParams:
         AttentionParams: The attention parameters modified with tensor parallelism, allowing for distributed computation across multiple devices.
     """
     q_proj, k_proj, v_proj, o_proj = params
-    # q_proj = einshard(q_proj, 'm r h k -> m r h1* k')
-    # k_proj = einshard(k_proj, 'm h k -> m h1* k')
-    # v_proj = einshard(v_proj, 'm h v -> m h1* v')
-    # o_proj = einshard(o_proj, 'r h v m -> r h1* v m')
-    q_proj = einshard(q_proj, 'm r h k -> m r h k1*')
-    k_proj = einshard(k_proj, 'm h k -> m h k1*')
-    v_proj = einshard(v_proj, 'm h v -> m h v1*')
-    o_proj = einshard(o_proj, 'r h v m -> r h v1* m')
+    # q_proj = einshard(q_proj, 'm r h k -> m r h* k')
+    # k_proj = einshard(k_proj, 'm h k -> m h* k')
+    # v_proj = einshard(v_proj, 'm h v -> m h* v')
+    # o_proj = einshard(o_proj, 'r h v m -> r h* v m')
+    q_proj = einshard(q_proj, 'm r h k -> m r h k*')
+    k_proj = einshard(k_proj, 'm h k -> m h k*')
+    v_proj = einshard(v_proj, 'm h v -> m h v*')
+    o_proj = einshard(o_proj, 'r h v m -> r h v* m')
     return q_proj, k_proj, v_proj, o_proj
 
 def forward_attention(params: AttentionParams, seq: Array, qk_mask: Array, rotary_values: RotaryValues, kv_cache_cur: KVCache, kv_cache_pre: KVCache) -> tuple[Array, KVCache, KVCache]:

--- a/mistral/model/mistral_lm.py
+++ b/mistral/model/mistral_lm.py
@@ -40,7 +40,7 @@ def shard_mistral_lm_params(params: MistralLMParams) -> MistralLMParams:
     """
     model_params, lm_head = params
     model_params = shard_mistral_model_params(model_params)
-    lm_head = einshard(lm_head, '... -> 1* ...')
+    lm_head = einshard(lm_head, '... -> * ...')
     return model_params, lm_head
 
 def forward_mistral_lm(params: MistralLMParams, input_ids: Array, qk_mask: Array, rotary_values: RotaryValues, kv_cache_pre: KVCache) -> tuple[Array, KVCache]:

--- a/mistral/model/mlp_layer.py
+++ b/mistral/model/mlp_layer.py
@@ -39,9 +39,9 @@ def shard_mlp_layer_params(params: MLPLayerParams) -> MLPLayerParams:
         MLPLayerParams: The decoder embedding parameters replica for distributed computation across multiple devices.
     """
     gate_proj, up_proj, down_proj = params
-    gate_proj = einshard(gate_proj, 'm f -> m f1*')
-    up_proj = einshard(up_proj, 'm f -> m f1*')
-    down_proj = einshard(down_proj, 'f m -> f1* m')
+    gate_proj = einshard(gate_proj, 'm f -> m f*')
+    up_proj = einshard(up_proj, 'm f -> m f*')
+    down_proj = einshard(down_proj, 'f m -> f* m')
     return gate_proj, up_proj, down_proj
 
 def forward_mlp_layer(params: MLPLayerParams, seq: Array) -> Array:

--- a/mistral/model/rms_norm.py
+++ b/mistral/model/rms_norm.py
@@ -41,7 +41,7 @@ def shard_rms_norm_params(params: RMSNormParams) -> RMSNormParams:
     Returns:
         RMSNormParams: The rms norm parameters replica for distributed computation across multiple devices.
     """
-    return einshard(params, '... -> 1* ...')
+    return einshard(params, '... -> * ...')
 
 # Taken from https://github.com/ayaka14732/llama-2-jax/blob/main/lib/llama/rms_norm.py
 def forward_rms_norm(params: RMSNormParams, x: Array) -> Array:

--- a/tests/test_einshard.py
+++ b/tests/test_einshard.py
@@ -1,0 +1,80 @@
+from pathlib import Path; import sys; sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+import os
+import subprocess
+
+from jax import Array
+import jax.numpy as jnp
+
+from mistral.lib.einshard import einshard
+
+def set_device_count(n: int) -> None:
+    os.environ['JAX_PLATFORMS'] = 'cpu'
+    os.environ['XLA_FLAGS'] = os.environ.get('XLA_FLAGS', '') + f' --xla_force_host_platform_device_count={n}'
+
+def get_shard_shape(a: Array) -> tuple[int, ...]:
+    return a.addressable_data(0).shape
+
+def assert_equal(a, b):
+    if a != b:
+        raise AssertionError(f'{a} != {b}')
+
+tests = [
+    {
+        'n_devices': 1,
+        'shape': (2,),
+        'expr': '... -> 1* ...',
+        'ans': (2,),
+    },
+    {
+        'n_devices': 16,
+        'shape': (2,),
+        'expr': 'a -> 16 a',
+        'ans': (2,),
+    },
+    {
+        'n_devices': 16,
+        'shape': (2, 8),
+        'expr': 'a b -> 2 a b*',
+        'ans': (2, 1),
+    },
+    {
+        'n_devices': 8,
+        'shape': (4, 4),
+        'expr': 'a b -> 1* a* b*',
+        'ans': (2, 2),
+    },
+    {
+        'n_devices': 16,
+        'shape': (2, 8),
+        'expr': '... a -> 2 ... a*',
+        'ans': (2, 1),
+    },
+    {
+        'n_devices': 16,
+        'shape': (4, 16, 8),
+        'expr': 'a b c -> a2* b2 c*',
+        'ans': (1, 8, 4),
+    },
+]
+
+def invoke_test(spec) -> None:
+    set_device_count(spec['n_devices'])
+    a = jnp.zeros(spec['shape'])
+    a = einshard(a, spec['expr'])
+    assert_equal(get_shard_shape(a), spec['ans'])
+
+def main() -> None:
+    if len(sys.argv) < 2:  # no command-line arguments provided
+        for i in range(len(tests)):
+            result = subprocess.call([sys.executable, __file__, f'{i}'])
+            if result != 0:
+                print(f'❌ Test {i} failed')
+            else:
+                print(f'✅ Test {i} passed')
+    else:
+        i = int(sys.argv[1])
+        invoke_test(tests[i])
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_einshard.py
+++ b/tests/test_einshard.py
@@ -23,7 +23,7 @@ tests = [
     {
         'n_devices': 1,
         'shape': (2,),
-        'expr': '... -> 1* ...',
+        'expr': '... -> * ...',
         'ans': (2,),
     },
     {
@@ -41,7 +41,7 @@ tests = [
     {
         'n_devices': 8,
         'shape': (4, 4),
-        'expr': 'a b -> 1* a* b*',
+        'expr': 'a b -> * a* b*',
         'ans': (2, 2),
     },
     {


### PR DESCRIPTION
Simplify einshard syntax.

Now `1*` can be simply written as `*`, so that

```
a b -> 1* a b1*
```

can be now written as

```
a b -> * a b*
```

